### PR TITLE
feat: lighten box neutral on hover in dark mode

### DIFF
--- a/tokens/alias.box.dark.js
+++ b/tokens/alias.box.dark.js
@@ -7,7 +7,7 @@ module.exports = {
   box: {
     // Neutral
     "neutral-color"                            : { value: "{color.grey.70.value}", attributes: { category: "color" } },
-    "neutral-color-hover"                      : { value: "{color.grey.90.value}", attributes: { category: "color" } },
+    "neutral-color-hover"                      : { value: "{color.grey.60.value}", attributes: { category: "color" } },
     "neutral-color-pressed"                    : { value: "{color.grey.100.value}", attributes: { category: "color" } },
     "neutral-inverse-color"                    : { value: "{color.grey.0.value}", attributes: { category: "color" } },
     "neutral-inverse-color-hover"              : { value: "{color.grey.20.value}", attributes: { category: "color" } },


### PR DESCRIPTION
The previous hover color conflicted with base-alt, so the box background would just disappear into the base background.